### PR TITLE
fix(cli): ask user to select active provider after configuration

### DIFF
--- a/src/researchclaw/cli/providers_cmd.py
+++ b/src/researchclaw/cli/providers_cmd.py
@@ -105,6 +105,19 @@ def configure_providers_interactive(*, use_defaults: bool = False) -> None:
         if not click.confirm("Configure another provider?", default=False):
             break
 
+    # Ask which provider to enable
+    store = ProviderStore()
+    providers = store.list_providers()
+    if providers:
+        click.echo("\n--- Set Active Provider ---")
+        provider_names = [p["name"] for p in providers]
+        active_provider = prompt_choice(
+            "Select active provider:",
+            options=provider_names,
+        )
+        store.set_enabled(active_provider)
+        click.echo(f"✓ {active_provider} set as active provider")
+
 
 @click.group("models")
 def models_group() -> None:


### PR DESCRIPTION
## Summary

Fixes #5 — the `researchclaw models config` command now asks which provider to enable after configuration.

## Changes

- Added provider selection prompt after configuration in `configure_providers_interactive()`
- Ensures at least one provider is enabled when configuration completes
- User can now run `researchclaw app` immediately after `researchclaw models config` without "No model configured" errors

## Testing

- Verified the fix works locally by running `researchclaw models config` and selecting the active provider
- Command properly enables the selected provider in `~/.researchclaw.secret/providers.json`